### PR TITLE
Updating Gitleaks

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -10,6 +10,5 @@ permissions:
 jobs:
   scan:
     name: gitleaks
-    uses: ArcadiaPower/gitleaks-workflow/.github/workflows/gitleaks.yaml@5ae02b51d3614e5227a7d618e9e9d457cadae74a
+    uses: Urjanet/gitleaks-workflow/.github/workflows/gitleaks.yaml@f1e2e6f3b3190499b6ad214d3cc55fca908239ec
     secrets: inherit
-

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -32,3 +32,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+#


### PR DESCRIPTION

This pull request updates the `gitleaks` workflow configuration to use a different upstream repository and a newer commit for the workflow action.

**Workflow configuration update:**

* [`.github/workflows/gitleaks.yaml`](diffhunk://#diff-3a2cd6fa18bb7c3df983bdb28620a6641cbb40d8df67a2376bab357eb1156ca0L13-L15): Changed the `gitleaks` workflow to use `Urjanet/gitleaks-workflow` at commit `f1e2e6f3b3190499b6ad214d3cc55fca908239ec` instead of `ArcadiaPower/gitleaks-workflow`.